### PR TITLE
Inform user when using a multi-config cmake generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,14 @@ message(STATUS "Header files will be installed to: ${CMAKE_INSTALL_PREFIX}/${INC
 message(STATUS "Executables will be installed in: ${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_DIR}")
 message(STATUS "CMake config-files will be written to: ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DIR}")
 message(STATUS "${PROJECT_NAME} import target: ${PROJECT_NAMESPACE}::${TARGET_NAME}")
-message(STATUS "Building ${PROJECT_NAME} ${FULL_VERSION} in ${CMAKE_BUILD_TYPE} mode")
+if (CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "You are using a Multi-Configuration CMake Generator.")
+  message(STATUS "${PROJECT_NAME} ${FULL_VERSION} can be built for: "
+                 "${CMAKE_CONFIGURATION_TYPES}. Please be sure to specify the"
+                 " desired configuration (${CMAKE_BUILD_TYPE}) to the compiler.")
+else ()
+  message(STATUS "Building ${PROJECT_NAME} ${FULL_VERSION} in ${CMAKE_BUILD_TYPE} mode")
+endif ()
 if (PRIVATE_TESTS_ENABLED)
   message(STATUS "Private tests are enabled")
 endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,9 @@ platform:
   - x64
   - x86
 
-configuration: Debug
+configuration:
+  - Debug
+  - Release
 
 environment:
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,8 +38,8 @@ before_build:
   - dir
   
 build_script:
-  - cmake --build . --target install
-  
+  - cmake --build . --target install --config %configuration%
+
 test_script:
   - ctest -C Debug
 

--- a/readme.md
+++ b/readme.md
@@ -36,8 +36,19 @@ cmake -DCMAKE_BUILD_TYPE=debug -DBUILD_SHARED_LIBS=OFF ..
 #To make a release build, change `-DCMAKE_BUILD_TYPE=debug` to `-DCMAKE_BUILD_TYPE=release`  
 #To make a dynamic library, change `-DBUILD_SHARED_LIBS=OFF` to `-DBUILD_SHARED_LIBS=ON`
 
-#Build the library  
+#Using a Single-Configuration CMake generator, one can build the library using
 make
+#or
+cmake --build .
+
+#Using a Multi-Configuration CMake, one must also specifiy the correct
+#build configuration to compile the library with, i.e. "release", "debug", ...
+cmake --build --config <build configuration>
+#or
+xcodebuild -project Qt5Mqtt.xcodeproj -configuration <build configuration>
+#or
+msbuild QtMqtt.sln /p:Configuration=<build configuration>
+
 ```
 ### Run unit tests
 `make test`


### PR DESCRIPTION
When using XCode or Visual Studio - like Multi-Configuration CMake generators,
it does not suffice to specifiy the CMAKE_BUILD_TYPE before running the build.
In this case, the user needs to pass a flag to the compiler. This change will inform
the user that this is necessary.