### PR TITLE
Do not place find_package here.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,9 @@ make
 ## Usage
 Include the following in your `CMakeLists.txt` file  
 ```CMake
+find_package(Qt5Core)	
+find_package(Qt5NetWork)	
+find_package(Qt5WebSockets)
 find_package(Qt5Mqtt)
 
 target_link_libraries(<target> Qt5::Mqtt)

--- a/src/cmake/config.cmake.in
+++ b/src/cmake/config.cmake.in
@@ -11,12 +11,6 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/@CMAKE_CONFIG_FILE_BASE_NAME@Targets.cmake")
 
-# find_package will silently look for the dependencies and set the correct
-# include directories and link libraries
-find_package(Qt@QT_MAJOR_VERSION_REQUIRED@Core QUIET)
-find_package(Qt@QT_MAJOR_VERSION_REQUIRED@NetWork QUIET)
-find_package(Qt@QT_MAJOR_VERSION_REQUIRED@WebSockets QUIET)
-
 check_required_components(Qt@QT_MAJOR_VERSION_REQUIRED@Core
                           Qt@QT_MAJOR_VERSION_REQUIRED@Network
                           Qt@QT_MAJOR_VERSION_REQUIRED@WebSockets)


### PR DESCRIPTION
It overwrites the PACKAGE_PREFIX_DIR variable expanded from the @PACKAGE_INIT@ section.
This would mean that value of the INCLUDE_DIRS, which contains the PACKAGE_PREFIX_DIR, is changed to be relative to one of the dependencies.
This does not make sense.