### PR TITLE
ignore specified SSL errors + add userName and password to connect

### DIFF
--- a/src/qmqttclient.cpp
+++ b/src/qmqttclient.cpp
@@ -485,6 +485,14 @@ bool QMqttClientPrivate::sslErrorsAllowed(const QList<QSslError> &errors) const
 {
     if (!m_allowedSslErrors.isEmpty())
     {
+        // The QSslErrors received with the QWebSocket::sslErrors signal are probably defined with the QSslError constructor
+        // with a certificate QSslError::QSslError(QSslError::SslError error, const QSslCertificate &certificate)
+        // If m_allowedSslErrors is defined using the QSslError constructor without a certificate QSslError::QSslError(QSslError::SslError error),
+        // e.g. QSet({QSslError::HostNameMismatch, QSslError::SelfSignedCertificate, QSslError::SelfSignedCertificateInChain}),
+        // the subtraction is never empty.
+        // This is because the QSslErrors comparison operator compares both the error() and the certificate().
+        // If we construct a QSet<QSslError> with only the error() of the errors received with the QWebSocket::sslErrors signal,
+        // the subtraction is empty when needed.
         QSet<QSslError> errorsSet;
         for (const auto &error : errors)
         {

--- a/src/qmqttclient.cpp
+++ b/src/qmqttclient.cpp
@@ -584,6 +584,7 @@ void QMqttClientPrivate::makeSignalSlotConnections()
   \a clientId should be a unique id representing the connection.
   The length of the \a clientId should be larger than smaller than 24 characters.
   If an empty \a clientId is provided, the server will generate a random one.
+  \a allowedSslErrors: specify any SSL errors you want to allow
  */
 QMqttClient::QMqttClient(const QString &clientId, const QSet<QSslError> &allowedSslErrors, QObject *parent) :
     QObject(parent),
@@ -611,6 +612,10 @@ QMqttClient::~QMqttClient()
 
   During setup of the connection, the state of the client will change from DISCONNECTED over
   CONNECTING to CONNECTED.
+  \a userName: specify the userName to be used with connect; connect QMqttPublishControlPacket
+  does not contain this userName if it is empty
+  \a password: specify the password to be used with connect; connect QMqttPublishControlPacket
+  does not contain this password if it is null (use QByteArray() as a null password)
 
   \sa disconnect(), stateChanged()
  */

--- a/src/qmqttclient.cpp
+++ b/src/qmqttclient.cpp
@@ -490,7 +490,7 @@ bool QMqttClientPrivate::sslErrorsAllowed(const QList<QSslError> &errors) const
         {
             errorsSet << QSslError(error.error());
         }
-        QSet<QSslError> subtraction = errorsSet.subtract(m_allowedSslErrors);
+        const QSet<QSslError> subtraction = errorsSet.subtract(m_allowedSslErrors);
         if (subtraction.isEmpty())
         {
             return true;

--- a/src/qmqttclient.cpp
+++ b/src/qmqttclient.cpp
@@ -491,14 +491,20 @@ bool QMqttClientPrivate::sslErrorsAllowed(const QList<QSslError> &errors) const
         // e.g. QSet({QSslError::HostNameMismatch, QSslError::SelfSignedCertificate, QSslError::SelfSignedCertificateInChain}),
         // the subtraction is never empty.
         // This is because the QSslErrors comparison operator compares both the error() and the certificate().
-        // If we construct a QSet<QSslError> with only the error() of the errors received with the QWebSocket::sslErrors signal,
-        // the subtraction is empty when needed.
+        // The comparison is empty when needed:
+        // 1. if we construct a QSet<QSslError> errorsSet with only the error() of the errors received with the QWebSocket::sslErrors signal
+        // 2. and if we construct a QSet<QSslError> allowedErrors with only the error() of m_allowedSslErrors
         QSet<QSslError> errorsSet;
         for (const auto &error : errors)
         {
             errorsSet << QSslError(error.error());
         }
-        const QSet<QSslError> subtraction = errorsSet.subtract(m_allowedSslErrors);
+        QSet<QSslError> allowedErrors;
+        for (const auto &allowedError : m_allowedSslErrors)
+        {
+            allowedErrors << QSslError(allowedError.error());
+        }
+        const QSet<QSslError> subtraction = errorsSet.subtract(allowedErrors);
         if (subtraction.isEmpty())
         {
             return true;

--- a/src/qmqttclient.h
+++ b/src/qmqttclient.h
@@ -27,7 +27,7 @@ public:
     virtual ~QMqttClient();
 
     using QObject::connect;
-    void connect(const QMqttNetworkRequest &request, const QMqttWill &will =  QMqttWill());
+    void connect(const QMqttNetworkRequest &request, const QMqttWill &will = QMqttWill(), const QString &userName = QString(), const QByteArray &password = QByteArray());
     using QObject::disconnect;
     void disconnect();
 

--- a/src/qmqttclient.h
+++ b/src/qmqttclient.h
@@ -2,6 +2,8 @@
 
 #include <QObject>
 #include <QHostAddress>
+#include <QSet>
+#include <QSslError>
 #include <functional>
 #include "qmqttwill.h"
 #include "qmqttprotocol.h"
@@ -21,7 +23,7 @@ class QTMQTT_EXPORT QMqttClient : public QObject
     Q_DISABLE_COPY(QMqttClient)
 
 public:
-    QMqttClient(const QString &clientId, QObject *parent = nullptr);
+    QMqttClient(const QString &clientId, const QSet<QSslError> &allowedSslErrors, QObject *parent = nullptr);
     virtual ~QMqttClient();
 
     using QObject::connect;

--- a/src/qmqttclient.h
+++ b/src/qmqttclient.h
@@ -23,7 +23,7 @@ class QTMQTT_EXPORT QMqttClient : public QObject
     Q_DISABLE_COPY(QMqttClient)
 
 public:
-    QMqttClient(const QString &clientId, const QSet<QSslError> &allowedSslErrors, QObject *parent = nullptr);
+    QMqttClient(const QString &clientId, const QSet<QSslError> &allowedSslErrors = QSet<QSslError>(), QObject *parent = nullptr);
     virtual ~QMqttClient();
 
     using QObject::connect;

--- a/src/qmqttclient_p.h
+++ b/src/qmqttclient_p.h
@@ -24,7 +24,7 @@ public:
     QMqttClientPrivate(const QString &clientId, const QSet<QSslError> &allowedSslErrors, QMqttClient * const q);
     virtual ~QMqttClientPrivate();
 
-    void connect(const QMqttNetworkRequest &request, const QMqttWill &will);
+    void connect(const QMqttNetworkRequest &request, const QMqttWill &will, const QString &userName, const QByteArray &password);
     void disconnect();
     void subscribe(const QString &topic, QMqttProtocol::QoS qos, std::function<void(bool)> cb);
     void unsubscribe(const QString &topic, std::function<void (bool)> cb);
@@ -52,6 +52,8 @@ private:
     QMqttWill m_will;
     bool m_signalSlotConnected;
     const QSet<QSslError> m_allowedSslErrors;
+    QString m_userName;
+    QByteArray m_password;
 
 private Q_SLOTS:
     void onSocketConnected();

--- a/src/qmqttclient_p.h
+++ b/src/qmqttclient_p.h
@@ -21,7 +21,7 @@ class QMqttClientPrivate : public QObject
     Q_DECLARE_PUBLIC(QMqttClient)
 
 public:
-    QMqttClientPrivate(const QString &clientId, QMqttClient * const q);
+    QMqttClientPrivate(const QString &clientId, const QSet<QSslError> &allowedSslErrors, QMqttClient * const q);
     virtual ~QMqttClientPrivate();
 
     void connect(const QMqttNetworkRequest &request, const QMqttWill &will);
@@ -51,6 +51,7 @@ private:
     QMap<uint16_t, std::function<void(bool)>> m_subscribeCallbacks;
     QMqttWill m_will;
     bool m_signalSlotConnected;
+    const QSet<QSslError> m_allowedSslErrors;
 
 private Q_SLOTS:
     void onSocketConnected();
@@ -64,6 +65,7 @@ private Q_SLOTS:
     void onPongReceived();
 
 private: //helpers
+    bool sslErrorsAllowed(const QList<QSslError> &sslErrors) const;
     void makeSignalSlotConnections();
 
     void sendData(const QByteArray &data);


### PR DESCRIPTION
In this pull request: 
1. allow specified SSL errors; functionality does not change if no allowed SSL errors are specified (= default)
2. add userName and password to connect QMqttConnectControlPacket; functionality does not change if an empty userName (= default) is specified; functionality also does not change when a null QByteArray password (= default) is specified